### PR TITLE
Fix pre-commit legacy hook causing pytest error

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ Both packages follow the standard `src` layout for clean and maintainable code.
 
 ### Prerequisites
 
--   **SCIP Optimization Suite**: This project uses `pyscipopt`, which requires a working installation of the SCIP Optimization Suite. You can download it from the [official SCIP website](https://scipopt.org/index.php#download). Please follow their installation instructions.
 -   Python 3.11+
 -   [uv](https://github.com/astral-sh/uv): A fast Python package installer.
 -   [Docker](https://www.docker.com/): For running the application in a container.

--- a/remip-client/README.md
+++ b/remip-client/README.md
@@ -1,0 +1,122 @@
+# ReMIP Client
+
+**ReMIP Client** is a Python client library for integrating with the ReMIP server. It provides a PuLP-compatible solver interface for solving Mixed-Integer Programming (MIP) problems remotely.
+
+## Overview
+
+The ReMIP Client allows you to leverage the capabilities of the ReMIP server without disrupting existing PuLP workflows. It eliminates the need for local solver installation and configuration, making it easy to use cloud-based optimization solutions.
+
+## Features
+
+- **PuLP Compatibility**: Use with existing PuLP code without modifications
+- **Remote Execution**: Solve MIP problems without using local resources
+- **Streaming Support**: Monitor solver progress in real-time
+- **Simple Integration**: Integrate with existing projects with minimal code changes
+
+## Installation
+
+```bash
+# Navigate to the remip-client directory
+cd remip-client
+
+# Install the client
+uv pip install -e .
+```
+
+## Usage
+
+### Basic Example
+
+```python
+from pulp import LpProblem, LpVariable, LpMaximize, LpStatus
+from remip_client.solver import ReMIPSolver
+
+# 1. Define a problem
+prob = LpProblem("test_problem", LpMaximize)
+x = LpVariable("x", 0, 1, cat='Binary')
+y = LpVariable("y", 0, 1, cat='Binary')
+prob += x + y, "objective"
+prob += 2*x + y <= 2, "constraint1"
+
+# 2. Initialize the remote solver for a non-streaming request
+solver = ReMIPSolver(stream=False)
+
+# 3. Solve the problem
+prob.solve(solver)
+
+# 4. Print the results
+print(f"Status: {LpStatus[prob.status]}")
+for v in prob.variables():
+    print(f"{v.name} = {v.varValue}")
+```
+
+### Using Streaming Functionality
+
+```python
+# To get a stream of solver events, set stream=True
+streaming_solver = ReMIPSolver(stream=True)
+
+# The client will print log and metric events to the console
+prob.solve(streaming_solver)
+```
+
+### Customizing Server Configuration
+
+```python
+# Initialize solver with custom server URL
+solver = ReMIPSolver(
+    server_url="http://your-remip-server:8000",
+    stream=False
+)
+```
+
+## API Reference
+
+### ReMIPSolver
+
+A PuLP-compatible solver class for communicating with the ReMIP server.
+
+#### Parameters
+
+- `server_url` (str, optional): URL of the ReMIP server. Defaults to `"http://localhost:8000"`
+- `stream` (bool, optional): Whether to enable streaming mode. Defaults to `True`
+
+#### Methods
+
+- `solve(problem)`: Solves a PuLP problem and returns the results
+
+## Testing
+
+To run the test suite:
+
+```bash
+uv run pytest
+```
+
+## Project Structure
+
+This package follows the standard `src` layout:
+
+```
+remip-client/
+├── src/
+│   └── remip_client/
+│       ├── __init__.py
+│       └── solver.py
+├── tests/
+│   ├── browser/
+│   ├── node/
+│   └── test_solver.py
+└── pyproject.toml
+```
+
+## Dependencies
+
+- Python 3.11+
+- PuLP
+- requests
+- sseclient-py (for streaming functionality)
+
+## License
+
+This project is licensed under the Apache License 2.0. See the [LICENSE](../LICENSE) file for details.

--- a/remip/README.md
+++ b/remip/README.md
@@ -1,3 +1,90 @@
-remip
+# ReMIP Server
 
-This is the README for the remip Python package.
+**ReMIP** (Remote Execution for Mixed-Integer Programming) server is a FastAPI-based web service for solving Mixed-Integer Programming (MIP) problems.
+
+## Overview
+
+The ReMIP server directly integrates with the SCIP Optimization Suite and solves MIP problems through a RESTful API. It provides real-time logging functionality and streaming capabilities through Server-Sent Events (SSE).
+
+## Features
+
+- **RESTful API**: Solve MIP problems through a clean and modern API
+- **Real-time Logging**: Stream solver logs in real-time to monitor progress
+- **PySCIPOpt Integration**: Directly integrates with the SCIP Optimization Suite through its Python API for better performance and stability
+- **Containerized**: Comes with a Docker setup for easy and consistent deployment
+
+## Prerequisites
+
+- **SCIP Optimization Suite**: This project uses `pyscipopt`, which requires a working installation of the SCIP Optimization Suite. You can download it from the [official SCIP website](https://scipopt.org/index.php#download).
+- Python 3.11+
+- [uv](https://github.com/astral-sh/uv): A fast Python package installer
+- [Docker](https://www.docker.com/): For running the application in a container
+
+## Installation
+
+1. **Create a virtual environment:**
+   ```bash
+   uv venv
+   ```
+
+2. **Install the server and its dependencies:**
+   ```bash
+   # This command installs the server and test dependencies
+   uv pip install -e .[test]
+   ```
+
+## Running
+
+To run the API server locally:
+
+```bash
+uv run remip
+```
+
+The API will be available at `http://localhost:8000`.
+
+## API Endpoints
+
+- `POST /solve`: Submits a MIP problem. Returns the final solution as JSON. If the `stream=sse` query parameter is provided or the `Accept` header is `text/event-stream`, it streams solver events using Server-Sent Events (SSE).
+- `GET /solver-info`: Returns information about the configured solver.
+
+## Testing
+
+To run the test suite:
+
+```bash
+uv run pytest
+```
+
+## Docker
+
+To build and run the application using Docker:
+
+```bash
+docker-compose build
+docker-compose up
+```
+
+## Project Structure
+
+This package follows the standard `src` layout for clean and maintainable code:
+
+```
+remip/
+├── src/
+│   └── remip/
+│       ├── __init__.py
+│       ├── main.py
+│       ├── models.py
+│       ├── services.py
+│       └── solvers/
+│           └── scip_wrapper.py
+├── tests/
+├── Dockerfile
+├── docker-compose.yml
+└── pyproject.toml
+```
+
+## License
+
+This project is licensed under the Apache License 2.0. See the [LICENSE](../LICENSE) file for details.

--- a/remip/pyproject.toml
+++ b/remip/pyproject.toml
@@ -25,7 +25,7 @@ build-backend = "hatchling.build"
 source = "vcs"
 fallback-version = "0.1.0"
 
-# setuptools-scm を親ディレクトリの .git を基準に動かす
+# setuptools-scm to use parent directory's .git as reference
 [tool.setuptools_scm]
 root = ".."
 

--- a/remip/src/remip/solvers/scip_wrapper.py
+++ b/remip/src/remip/solvers/scip_wrapper.py
@@ -92,12 +92,12 @@ class ScipSolverWrapper:
     def _run_solver_in_thread(self, model: Model, log_queue: asyncio.Queue, stop_event: threading.Event):
         """Target function for the solver thread."""
 
-        # PySCIPOptの最新バージョンではsetMessagehdlrが利用できないため、
-        # 代わりに標準出力をキャプチャしてログを取得する
+        # In the latest version of PySCIPOpt, setMessagehdlr is not available,
+        # so we capture standard output to get logs instead
         import sys
         from io import StringIO
 
-        # 標準出力をキャプチャ
+        # Capture standard output
         old_stdout = sys.stdout
         captured_output = StringIO()
         sys.stdout = captured_output
@@ -105,11 +105,11 @@ class ScipSolverWrapper:
         try:
             model.optimize()
         finally:
-            # 標準出力を復元
+            # Restore standard output
             sys.stdout = old_stdout
             captured_output.seek(0)
 
-            # キャプチャされた出力をログキューに送信
+            # Send captured output to log queue
             for line in captured_output:
                 if line.strip():
                     asyncio.run_coroutine_threadsafe(log_queue.put(line.strip()), asyncio.get_running_loop())

--- a/remip/tests/test_solver_wrapper.py
+++ b/remip/tests/test_solver_wrapper.py
@@ -64,5 +64,5 @@ async def test_solve_and_stream_events_optimizes_model(MockModel, solver_wrapper
         pass
 
     # Assert
-    # 新しい実装ではsetMessagehdlrの代わりにoptimizeが呼ばれる
+    # In the new implementation, optimize is called instead of setMessagehdlr
     mock_model_instance.optimize.assert_called_once()


### PR DESCRIPTION
## Problem

The pre-commit hook was causing the following error:

pytest

## Root Cause

The  file was an old custom script that was trying to call  directly. Since pytest was not installed in the system PATH, it was failing.

## Solution

- Removed the  file
- Configured to use only the standard pre-commit hook

This ensures that the pre-commit hook works correctly and uses  to execute tests.

## Changes

- Removed  file
- Maintained standard pre-commit hook configuration

## Testing

- Verified that On branch fix/pre-commit-legacy-hook
Your branch is up to date with 'origin/fix/pre-commit-legacy-hook'.

nothing to commit, working tree clean runs the pre-commit hook correctly
- Confirmed that all checks (ruff, pytest, etc.) pass successfully