### PR TITLE
fix(ci): update deprecated GitHub Actions to v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -26,13 +26,13 @@ jobs:
         run: python -m build --sdist --wheel -o dist/client ./remip-client
 
       - name: Upload server artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: server-package
           path: dist/server/
 
       - name: Upload client artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: client-package
           path: dist/client/
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: dist
 


### PR DESCRIPTION
The release workflow was failing due to the use of a deprecated version of actions/upload-artifact (v3).

This change updates the following actions to v4 to resolve the issue and prevent future deprecation problems:
- actions/checkout
- actions/upload-artifact
- actions/download-artifact
