### PR TITLE
fix(solver): Handle SOS constraints correctly

### DIFF
--- a/remip/src/remip/solvers/scip_wrapper.py
+++ b/remip/src/remip/solvers/scip_wrapper.py
@@ -172,20 +172,24 @@ class ScipSolverWrapper:
 
         # Add SOS constraints
         if problem.sos1:
-            for sos_dict in problem.sos1:
-                for name, weights_dict in sos_dict.items():
-                    sos_vars = [vars[var_name] for var_name in weights_dict.keys() if var_name in vars]
-                    weights = [weight for var_name, weight in weights_dict.items() if var_name in vars]
-                    if sos_vars:
-                        model.addConsSOS1(sos_vars, weights, name=name)
+            for i, weights_dict in enumerate(problem.sos1):
+                if not isinstance(weights_dict, dict):
+                    continue
+                name = f"sos1_{i}"
+                sos_vars = [vars[var_name] for var_name in weights_dict.keys() if var_name in vars]
+                weights = [weight for var_name, weight in weights_dict.items() if var_name in vars]
+                if sos_vars:
+                    model.addConsSOS1(sos_vars, weights, name=name)
 
         if problem.sos2:
-            for sos_dict in problem.sos2:
-                for name, weights_dict in sos_dict.items():
-                    sos_vars = [vars[var_name] for var_name in weights_dict.keys() if var_name in vars]
-                    weights = [weight for var_name, weight in weights_dict.items() if var_name in vars]
-                    if sos_vars:
-                        model.addConsSOS2(sos_vars, weights, name=name)
+            for i, weights_dict in enumerate(problem.sos2):
+                if not isinstance(weights_dict, dict):
+                    continue
+                name = f"sos2_{i}"
+                sos_vars = [vars[var_name] for var_name in weights_dict.keys() if var_name in vars]
+                weights = [weight for var_name, weight in weights_dict.items() if var_name in vars]
+                if sos_vars:
+                    model.addConsSOS2(sos_vars, weights, name=name)
 
         # Apply solver options
         if problem.solver_options:

--- a/remip/tests/test_solver_wrapper.py
+++ b/remip/tests/test_solver_wrapper.py
@@ -110,7 +110,7 @@ async def test_build_model_with_sos1(MockModel, solver_wrapper):
             Variable(name="x_B", lower_bound=0, upper_bound=1, category="Binary"),
             Variable(name="x_C", lower_bound=0, upper_bound=1, category="Binary"),
         ],
-        sos1=[{"weights": {"x_A": 1, "x_B": 2, "x_C": 3}}],
+        sos1=[{"x_A": 1, "x_B": 2, "x_C": 3}],
     )
 
     # Act


### PR DESCRIPTION
This PR fixes a bug where the solver would crash when processing SOS constraints due to an incorrect data model. The SCIP wrapper has been updated to correctly handle the data format sent by the remip-client, and the tests have been updated to reflect this change.