### PR TITLE
feat: Unify solver timeout terminology

### DIFF
--- a/docs/develop/design.md
+++ b/docs/develop/design.md
@@ -81,7 +81,7 @@ This document outlines the final technical design for implementing a server-side
 - The `solve_and_stream_events` method will accept the `timeout` value.
 - If a timeout is provided, an `asyncio` watchdog task will be started. This task will sleep for the specified duration.
 - If the watchdog's sleep completes before the solver finishes, it will call `model.interruptSolve()` in a thread-safe manner to gracefully stop the optimization process.
-- The `_extract_solution` method will check the solver status. If the status is `"userinterrupt"` (the result of calling `interruptSolve()`), it will be mapped to our application's `"timelimit"` status in the final `MIPSolution`.
+- The `_extract_solution` method will check the solver status. If the status is `"userinterrupt"` (the result of calling `interruptSolve()`), it will be mapped to our application's `"timeout"` status in the final `MIPSolution`.
 
 ## 3. Data Flow Example
 
@@ -91,5 +91,5 @@ This document outlines the final technical design for implementing a server-side
 4.  The `timeout` value is passed through the service layer to the `ScipSolverWrapper`.
 5.  The wrapper starts the solver in a background thread and concurrently starts a 60-second watchdog timer.
 6.  If 60 seconds pass, the watchdog interrupts the solver.
-7.  The wrapper catches the interruption, checks the solver status (`"userinterrupt"`), and creates a `MIPSolution` with `"status": "timelimit"`.
+7.  The wrapper catches the interruption, checks the solver status (`"userinterrupt"`), and creates a `MIPSolution` with `"status": "timeout"`.
 8.  The server sends this solution back to the client.

--- a/docs/develop/tasks.md
+++ b/docs/develop/tasks.md
@@ -23,7 +23,7 @@ This document breaks down the implementation of the server-side timeout feature 
     -   **File**: `remip/src/remip/solvers/scip_wrapper.py`
     -   **Action**: Update the signatures of `solve` and `solve_and_stream_events` to accept the `timeout: Optional[float]` parameter.
     -   **Action**: In `solve_and_stream_events`, if `timeout` is provided, create and manage an `asyncio` watchdog task that calls `model.interruptSolve()` after the specified duration.
-    -   **Action**: In `_extract_solution`, check for the `"userinterrupt"` status from the solver and map it to `"timelimit"` in the returned `MIPSolution`.
+    -   **Action**: In `_extract_solution`, check for the `"userinterrupt"` status from the solver and map it to `"timeout"` in the returned `MIPSolution`.
 
 ## 3. Client-Side Implementation (`remip-client`)
 

--- a/docs/develop/test-design.md
+++ b/docs/develop/test-design.md
@@ -32,7 +32,7 @@ These end-to-end tests will use a real `TestClient` without a mocked service to 
 
 ### Test Case: `test_solve_with_timeout_triggers`
 
-- **Objective**: Verify that the solver terminates early and returns a `timelimit` status when the timeout is reached.
+- **Objective**: Verify that the solver terminates early and returns a `timeout` status when the timeout is reached.
 - **Setup**:
     1.  Construct a knapsack problem that takes several seconds to solve.
 - **Action**:

--- a/remip-client/src/remip_client/solver.py
+++ b/remip-client/src/remip_client/solver.py
@@ -118,7 +118,7 @@ class ReMIPSolver(LpSolver):
             "infeasible": constants.LpStatusInfeasible,
             "unbounded": constants.LpStatusUnbounded,
             "not solved": constants.LpStatusNotSolved,
-            "timelimit": constants.LpStatusNotSolved,
+            "timeout": constants.LpStatusNotSolved,
         }
         lp.status = status_map.get(solution["status"], constants.LpStatusUndefined)
         if solution.get("objective_value") is not None:

--- a/remip/README.md
+++ b/remip/README.md
@@ -40,7 +40,7 @@ The request body must be a JSON object representing the MIP problem, conforming 
 
 **Query Parameters**:
 
--   `timeout` (float, optional): The maximum time in seconds that the solver is allowed to run. If the time limit is reached, the solver will be interrupted, and the best solution found so far will be returned with a `"timelimit"` status.
+-   `timeout` (float, optional): The maximum time in seconds that the solver is allowed to run. If the time limit is reached, the solver will be interrupted, and the best solution found so far will be returned with a `"timeout"` status.
 -   `stream` (string, optional): If set to `sse`, the server will stream solver events (logs, metrics, and results) using Server-Sent Events. This is useful for monitoring long-running tasks.
 
 **Responses**:

--- a/remip/src/remip/solvers/scip_wrapper.py
+++ b/remip/src/remip/solvers/scip_wrapper.py
@@ -211,8 +211,8 @@ class ScipSolverWrapper:
             "optimal": "optimal",
             "infeasible": "infeasible",
             "unbounded": "unbounded",
-            "timelimit": "timelimit",
-            "userinterrupt": "timelimit",  # Map interrupt to timelimit
+            "timelimit": "timeout",
+            "userinterrupt": "timeout",  # Map interrupt to timeout
             "gaplimit": "gaplimit",
             "solutionlimit": "solutionlimit",
             "memorylimit": "memorylimit",

--- a/remip/tests/test_timeout.py
+++ b/remip/tests/test_timeout.py
@@ -131,5 +131,5 @@ def test_solve_with_timeout_triggers(real_solver_client, tsptw_problem):
     response = real_solver_client.post("/solve?timeout=1", json=tsptw_problem)
     assert response.status_code == 200
     solution = response.json()
-    # The status should be 'timelimit' because the solver was interrupted
-    assert solution["status"] == "timelimit"
+    # The status should be 'timeout' because the solver was interrupted
+    assert solution["status"] == "timeout"


### PR DESCRIPTION
The parameter to control the solver's time limit was 'timeout', but the status returned was 'timelimit'.

This commit unifies the terminology by changing the returned status to 'timeout' for consistency. It also adds a GEMINI.md instruction file for project-specific agent behavior.